### PR TITLE
Remove dependencies to sample_app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ include_directories(fsw/src)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
 include_directories(${ci_lab_MISSION_DIR}/fsw/platform_inc)
-include_directories(${sample_app_MISSION_DIR}/fsw/platform_inc)
 
 aux_source_directory(fsw/src APP_SRC_FILES)
 

--- a/fsw/tables/to_lab_sub.c
+++ b/fsw/tables/to_lab_sub.c
@@ -42,8 +42,6 @@
 #include "to_lab_msgids.h"
 #include "ci_lab_msgids.h"
 
-#include "sample_app_msgids.h"
-
 #if 0
 #include "hs_msgids.h"
 #include "fm_msgids.h"
@@ -60,7 +58,6 @@ TO_LAB_Subs_t TO_LAB_Subs =
         {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_HK_TLM_MID), {0, 0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(TO_LAB_DATA_TYPES_MID), {0, 0}, 4},
         {CFE_SB_MSGID_WRAP_VALUE(CI_LAB_HK_TLM_MID), {0, 0}, 4},
-        {CFE_SB_MSGID_WRAP_VALUE(SAMPLE_APP_HK_TLM_MID), {0, 0}, 4},
 
     #if 0
         /* Add these if needed */


### PR DESCRIPTION
Since the `sample_app` and the `sample_lib` will not be included in our flight repo, dependencies to them are removed from the code.